### PR TITLE
Trigger `Lint and test` on push only for the master branch.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: 'Lint and test'
 
 on:
   push:
+    branches: [ master ]
     paths-ignore:
       - 'doc/**'
       - '**.md'


### PR DESCRIPTION
Else, when pushing to a branch and creating a PR, duplicate jobs are triggered.