### PR TITLE
Describe new permission to help users granting the role

### DIFF
--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -43,6 +43,11 @@ de:
           debit: Lastschrift
           invoice: Rechnung
         pronoun: Pronomen
+      role:
+        class:
+          permission:
+            description:
+              group_and_below_efz: "Zeugnisse nach SGB VIII erfassen in dieser Gruppen und deren Untergruppen."
     errors:
       models:
         fee_kind:


### PR DESCRIPTION
If this is not set, the role-description is incomplete.